### PR TITLE
fix: Fix SQL migration syntax errors

### DIFF
--- a/migrations/007_create_agent_feedback.sql
+++ b/migrations/007_create_agent_feedback.sql
@@ -93,20 +93,20 @@ ALTER TABLE public.agent_feedback ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Users can view their own feedback"
 ON public.agent_feedback
 FOR SELECT
-USING (created_by = auth.uid() OR created_by IS NULL);
+USING (created_by = auth.uid()::uuid OR created_by IS NULL);
 
 -- Users can insert their own feedback
 CREATE POLICY "Users can insert their own feedback"
 ON public.agent_feedback
 FOR INSERT
-WITH CHECK (created_by = auth.uid() OR created_by IS NULL);
+WITH CHECK (created_by = auth.uid()::uuid OR created_by IS NULL);
 
 -- Users can update their own feedback
 CREATE POLICY "Users can update their own feedback"
 ON public.agent_feedback
 FOR UPDATE
-USING (created_by = auth.uid())
-WITH CHECK (created_by = auth.uid());
+USING (created_by = auth.uid()::uuid)
+WITH CHECK (created_by = auth.uid()::uuid);
 
 -- Service role has full access
 CREATE POLICY "Service role has full access to feedback"

--- a/migrations/create_audit_logs_table.sql
+++ b/migrations/create_audit_logs_table.sql
@@ -460,8 +460,8 @@ COMMIT;
 -- END OF MIGRATION
 -- ============================================================================
 
-RAISE NOTICE '✅ Audit logs table created successfully';
-RAISE NOTICE '📊 Created 10 indexes for query performance';
-RAISE NOTICE '🔒 RLS enabled - admin-only access';
-RAISE NOTICE '🛠️  Created 3 helper functions for logging';
-RAISE NOTICE '✨ Sample data inserted for testing';
+-- ✅ Audit logs table created successfully
+-- 📊 Created 10 indexes for query performance
+-- 🔒 RLS enabled - admin-only access
+-- 🛠️  Created 3 helper functions for logging
+-- ✨ Sample data inserted for testing

--- a/migrations/enable_rls_policies.sql
+++ b/migrations/enable_rls_policies.sql
@@ -36,8 +36,7 @@ ALTER TABLE batch_operations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE user_document_connections ENABLE ROW LEVEL SECURITY;
 ALTER TABLE crewai_executions ENABLE ROW LEVEL SECURITY;
 
--- Log RLS enablement
-RAISE NOTICE 'RLS enabled on 14 user-facing tables';
+-- RLS enabled on 14 user-facing tables
 
 -- ============================================================================
 -- PHASE 2: CREATE RLS POLICIES FOR DATA ISOLATION
@@ -130,7 +129,7 @@ CREATE POLICY user_crewai_executions_policy ON crewai_executions
     current_setting('app.user_role', TRUE) = 'admin'
   );
 
-RAISE NOTICE 'Created RLS policies for 9 tables with direct user ownership';
+-- Created RLS policies for 9 tables with direct user ownership
 
 -- ----------------------------------------------------------------------------
 -- PATTERN 2: Foreign Key Ownership via Documents
@@ -172,7 +171,7 @@ CREATE POLICY user_processing_tasks_policy ON processing_tasks
     current_setting('app.user_role', TRUE) = 'admin'
   );
 
-RAISE NOTICE 'Created RLS policies for 3 tables with FK ownership via documents';
+-- Created RLS policies for 3 tables with FK ownership via documents
 
 -- ----------------------------------------------------------------------------
 -- PATTERN 3: Foreign Key Ownership via Chat Sessions
@@ -202,7 +201,7 @@ CREATE POLICY user_chat_feedback_policy ON chat_feedback
     current_setting('app.user_role', TRUE) = 'admin'
   );
 
-RAISE NOTICE 'Created RLS policies for 2 tables with FK ownership via chat_sessions';
+-- Created RLS policies for 2 tables with FK ownership via chat_sessions
 
 -- ============================================================================
 -- PHASE 3: CREATE PERFORMANCE INDEXES FOR RLS COLUMNS
@@ -227,7 +226,7 @@ CREATE INDEX IF NOT EXISTS idx_processing_tasks_document_id ON processing_tasks(
 CREATE INDEX IF NOT EXISTS idx_chat_messages_session_id ON chat_messages(session_id);
 CREATE INDEX IF NOT EXISTS idx_chat_feedback_session_id ON chat_feedback(session_id);
 
-RAISE NOTICE 'Created performance indexes for RLS columns';
+-- Created performance indexes for RLS columns
 
 -- ============================================================================
 -- PHASE 4: VERIFICATION QUERIES


### PR DESCRIPTION
## Summary
- Fix type mismatch in RLS policies (text vs uuid)
- Fix invalid RAISE NOTICE statements outside DO blocks

## Changes
- `007_create_agent_feedback.sql`: Cast `auth.uid()` to UUID for proper type comparison
- `create_audit_logs_table.sql`: Replace RAISE NOTICE with SQL comments
- `enable_rls_policies.sql`: Replace RAISE NOTICE with SQL comments

## Test plan
- [ ] CI/CD migrations should pass
- [ ] Deployment should succeed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)