### PR TITLE
fix: Migration runner upsert and notify-failure permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -380,6 +380,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test-unit, deploy-production, migrate-database]
     if: failure() && github.ref == 'refs/heads/main'
+    permissions:
+      issues: write
 
     steps:
       - name: Create GitHub Issue on Failure


### PR DESCRIPTION
## Summary
- **Migration runner**: Changed `INSERT` to `INSERT ... ON CONFLICT ... DO UPDATE` (upsert) when recording migration results. Previously, re-running a failed migration would hit a unique constraint violation on `schema_migrations.migration_name`, causing the retry to also fail. This has been breaking the `Run Database Migrations` job since PR #155.
- **Notify on Failure**: Added `permissions: issues: write` to the `notify-failure` job so it can create GitHub issues (was getting 403 "Resource not accessible by integration").

## Test plan
- [ ] Merge PR and verify the `Run Database Migrations` job passes on main (migration 008 should now succeed)
- [ ] If a future pipeline fails, verify the `Notify on Failure` job can create a GitHub issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with improved error reporting capabilities via GitHub issues.
  * Improved migration tracking with more comprehensive metadata on both successful and failed migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->