### PR TITLE
fix: Drop function overloads before CREATE OR REPLACE in migration 008

### DIFF
--- a/migrations/008_create_router_cache_functions.sql
+++ b/migrations/008_create_router_cache_functions.sql
@@ -53,6 +53,31 @@ END $$;
 -- RPC FUNCTIONS
 -- =============================================================================
 
+-- Drop any existing overloads to avoid "function name is not unique" errors
+-- when CREATE OR REPLACE encounters a different parameter signature.
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT oid::regprocedure::text AS sig
+        FROM pg_proc
+        WHERE proname = 'get_cached_routing'
+          AND pronamespace = 'public'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION IF EXISTS ' || r.sig || ' CASCADE';
+    END LOOP;
+
+    FOR r IN
+        SELECT oid::regprocedure::text AS sig
+        FROM pg_proc
+        WHERE proname = 'increment_cache_hit'
+          AND pronamespace = 'public'::regnamespace
+    LOOP
+        EXECUTE 'DROP FUNCTION IF EXISTS ' || r.sig || ' CASCADE';
+    END LOOP;
+END $$;
+
 -- Function to increment cache hit count
 -- Uses SET search_path to prevent search-path hijacking in SECURITY DEFINER
 CREATE OR REPLACE FUNCTION increment_cache_hit(p_cache_id UUID)


### PR DESCRIPTION
## Summary
- Migration 008 fails with `function name "get_cached_routing" is not unique` because an older overload with a different parameter signature exists in the database.
- Added a `DO` block that drops all existing overloads of `get_cached_routing` and `increment_cache_hit` before re-creating them with the correct signatures.

## Test plan
- [ ] Merge and verify `Run Database Migrations` job passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database migration process to prevent errors when deploying routing cache functions, ensuring smoother upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->